### PR TITLE
[Chore] Production Dependencies Update - 2025-09-30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/delivery-sdk": "^4.8.0",
-        "@contentstack/live-preview-utils": "^3.4.0",
-        "@timbenniks/contentstack-endpoints": "^1.0.14",
-        "dompurify": "^3.2.6",
-        "next": "15.4.6",
+        "@contentstack/delivery-sdk": "^4.10.0",
+        "@contentstack/live-preview-utils": "^4.0.2",
+        "@timbenniks/contentstack-endpoints": "^1.0.16",
+        "dompurify": "^3.2.7",
+        "next": "^15.5.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@contentstack/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-fAS4whkybRs0/KE/ENaXenl8LeMxR+wtwM1MbGWwyWTN0kfcGf5jRONH8e++qidJqjHe7JhfOZXVXc3I0RQEVQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-RuaqNMZreN/ihnFJtGvtxK5NYuQuar1qBwWf0wqMsESHZCp+7Ohk1iSwq5E+7JN8Rzz40eiBiXklllzhoC0+5g==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0",
@@ -71,21 +71,21 @@
       }
     },
     "node_modules/@contentstack/delivery-sdk": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/delivery-sdk/-/delivery-sdk-4.8.0.tgz",
-      "integrity": "sha512-XDXCl6rzA77hZ8i4K6x83eFUpXjnTB7eIKFcbXRuJ/dky+ZktoZEE/ld2uIry2DsI19cW9quSwAj62wPxqTASA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/delivery-sdk/-/delivery-sdk-4.10.0.tgz",
+      "integrity": "sha512-O1sYIdqBNHhopX5rReSZ2NvQwTCO1zSf2HLGdKlkyaTNfSYnb2OEMFIqgm4sZHnb1/qOVxDAi/4RLV6zjNBZVg==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/core": "^1.2.0",
-        "@contentstack/utils": "^1.4.0",
-        "axios": "^1.8.4",
+        "@contentstack/core": "^1.3.0",
+        "@contentstack/utils": "^1.4.1",
+        "axios": "^1.12.2",
         "humps": "^2.0.1"
       }
     },
     "node_modules/@contentstack/live-preview-utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/live-preview-utils/-/live-preview-utils-3.4.0.tgz",
-      "integrity": "sha512-nK28/1Xdc3C79CBTXle70qfaWi5SRs7nfR5l/CM0skW+Sc4Eate5h5bnZfji5U+O7kfxATut6wEixUVBH6jbVQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@contentstack/live-preview-utils/-/live-preview-utils-4.0.2.tgz",
+      "integrity": "sha512-BN0NItbsCZKuqGFFF3xGtiIjF7ZqxLIwwml1NGl1lxV2VqcdznOk31ZOjaYMxukySNWy8auQeatYPCxxt80/CQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.2",
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.6.tgz",
-      "integrity": "sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.4.tgz",
+      "integrity": "sha512-27SQhYp5QryzIT5uO8hq99C69eLQ7qkzkDPsk3N+GuS2XgOgoYEeOav7Pf8Tn4drECOVDsDg8oj+/DVy8qQL2A==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.6.tgz",
-      "integrity": "sha512-667R0RTP4DwxzmrqTs4Lr5dcEda9OxuZsVFsjVtxVMVhzSpo6nLclXejJVfQo2/g7/Z9qF3ETDmN3h65mTjpTQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.4.tgz",
+      "integrity": "sha512-nopqz+Ov6uvorej8ndRX6HlxCYWCO3AHLfKK2TYvxoSB2scETOcfm/HSS3piPqc3A+MUgyHoqE6je4wnkjfrOA==",
       "cpu": [
         "arm64"
       ],
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.6.tgz",
-      "integrity": "sha512-KMSFoistFkaiQYVQQnaU9MPWtp/3m0kn2Xed1Ces5ll+ag1+rlac20sxG+MqhH2qYWX1O2GFOATQXEyxKiIscg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.4.tgz",
+      "integrity": "sha512-QOTCFq8b09ghfjRJKfb68kU9k2K+2wsC4A67psOiMn849K9ZXgCSRQr0oVHfmKnoqCbEmQWG1f2h1T2vtJJ9mA==",
       "cpu": [
         "x64"
       ],
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.6.tgz",
-      "integrity": "sha512-PnOx1YdO0W7m/HWFeYd2A6JtBO8O8Eb9h6nfJia2Dw1sRHoHpNf6lN1U4GKFRzRDBi9Nq2GrHk9PF3Vmwf7XVw==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.4.tgz",
+      "integrity": "sha512-eRD5zkts6jS3VfE/J0Kt1VxdFqTnMc3QgO5lFE5GKN3KDI/uUpSyK3CjQHmfEkYR4wCOl0R0XrsjpxfWEA++XA==",
       "cpu": [
         "arm64"
       ],
@@ -925,9 +925,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.6.tgz",
-      "integrity": "sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.4.tgz",
+      "integrity": "sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==",
       "cpu": [
         "arm64"
       ],
@@ -941,9 +941,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.6.tgz",
-      "integrity": "sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.4.tgz",
+      "integrity": "sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==",
       "cpu": [
         "x64"
       ],
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.6.tgz",
-      "integrity": "sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.4.tgz",
+      "integrity": "sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==",
       "cpu": [
         "x64"
       ],
@@ -973,9 +973,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.6.tgz",
-      "integrity": "sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.4.tgz",
+      "integrity": "sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==",
       "cpu": [
         "arm64"
       ],
@@ -989,9 +989,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.6.tgz",
-      "integrity": "sha512-T4ufqnZ4u88ZheczkBTtOF+eKaM14V8kbjud/XrAakoM5DKQWjW09vD6B9fsdsWS2T7D5EY31hRHdta7QKWOng==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.4.tgz",
+      "integrity": "sha512-1ur2tSHZj8Px/KMAthmuI9FMp/YFusMMGoRNJaRZMOlSkgvLjzosSdQI0cJAKogdHl3qXUQKL9MGaYvKwA7DXg==",
       "cpu": [
         "x64"
       ],
@@ -1400,9 +1400,9 @@
       }
     },
     "node_modules/@timbenniks/contentstack-endpoints": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@timbenniks/contentstack-endpoints/-/contentstack-endpoints-1.0.14.tgz",
-      "integrity": "sha512-IOKO9B7trAgHjY8h1dlgKKpGNq2ErCupFg2X58b7gFhkcyagvITZ01wla/OWz7eY89+Z7rI1hZLfRNBe5fhAoA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@timbenniks/contentstack-endpoints/-/contentstack-endpoints-1.0.16.tgz",
+      "integrity": "sha512-P4KAofMdK34rIH+XNShudZSxGyo9mzTFYf98dBJLCFlxTeXJy0rDwPOmnQgJtULIvd4boUpJqNaKEzbNgRUp5w==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2314,9 +2314,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2767,9 +2767,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5012,12 +5012,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
-      "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
+      "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.6",
+        "@next/env": "15.5.4",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5030,14 +5030,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.6",
-        "@next/swc-darwin-x64": "15.4.6",
-        "@next/swc-linux-arm64-gnu": "15.4.6",
-        "@next/swc-linux-arm64-musl": "15.4.6",
-        "@next/swc-linux-x64-gnu": "15.4.6",
-        "@next/swc-linux-x64-musl": "15.4.6",
-        "@next/swc-win32-arm64-msvc": "15.4.6",
-        "@next/swc-win32-x64-msvc": "15.4.6",
+        "@next/swc-darwin-arm64": "15.5.4",
+        "@next/swc-darwin-x64": "15.5.4",
+        "@next/swc-linux-arm64-gnu": "15.5.4",
+        "@next/swc-linux-arm64-musl": "15.5.4",
+        "@next/swc-linux-x64-gnu": "15.5.4",
+        "@next/swc-linux-x64-musl": "15.5.4",
+        "@next/swc-win32-arm64-msvc": "15.5.4",
+        "@next/swc-win32-x64-msvc": "15.5.4",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@contentstack/delivery-sdk": "^4.8.0",
-    "@contentstack/live-preview-utils": "^3.4.0",
-    "@timbenniks/contentstack-endpoints": "^1.0.14",
-    "dompurify": "^3.2.6",
-    "next": "15.4.6",
+    "@contentstack/delivery-sdk": "^4.10.0",
+    "@contentstack/live-preview-utils": "^4.0.2",
+    "@timbenniks/contentstack-endpoints": "^1.0.16",
+    "dompurify": "^3.2.7",
+    "next": "^15.5.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },


### PR DESCRIPTION
This PR updates production dependencies to their latest versions.

**Changes:**
- @contentstack/delivery-sdk: 4.8.0 → 4.10.0
- @contentstack/live-preview-utils: 3.4.0 → 4.0.2
- @timbenniks/contentstack-endpoints: 1.0.14 → 1.0.16
- next: 15.4.6 → 15.5.4
- dompurify: 3.2.6 → 3.2.7

Build verification passed ✓

**Review Required:**
Please review the dependency changes and run tests before merging.

**Generated:** 2025-09-30